### PR TITLE
Added a view-claims feature and added admin_response in edit-claim page

### DIFF
--- a/agileapp/app/routes.py
+++ b/agileapp/app/routes.py
@@ -199,16 +199,23 @@ def edit_claim(claim_id):
     claim = Claim.query.get_or_404(claim_id)
     if request.method == 'POST':
         new_status = request.form.get('status')
+        new_response = request.form.get('admin_response')
+        
+        print(f"Updating claim {claim_id} with status: {new_status} and response: {new_response}")  # Debugging statement
+
         claim.status = new_status
+        claim.admin_response = new_response  # Update the admin_response field
+
         if new_status == 'Approved':
             update_item_status(claim.item_id)
+
         db.session.commit()
 
         notify_user_claim_response(claim)
         flash('Claim status updated successfully.', 'success')
         return redirect(url_for('admin_claims'))
 
-    return render_template('/admin/edit-claim.html', claim=claim)
+    return render_template('admin/edit-claim.html', claim=claim)
 
 def update_item_status(item_id):
     item = LostItem.query.get(item_id)
@@ -260,7 +267,11 @@ def admin_delete_item(item_id):
     flash('Item deleted successfully.', 'success')
     return redirect(url_for('admin_manage_items'))
 
-
+@app.route('/view-claims')
+@login_required
+def view_claims():
+    user_claims = db.session.query(Claim, LostItem).join(LostItem, Claim.item_id == LostItem.id).filter(Claim.claimer_id == current_user.id).all()
+    return render_template('view-claims.html', claims=user_claims)
 
 ##################################################################################################################
 # Handle Notifications

--- a/agileapp/app/templates/admin/edit-claim.html
+++ b/agileapp/app/templates/admin/edit-claim.html
@@ -3,27 +3,30 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/styles.css') }}">
     <title>Edit Claim</title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
 </head>
 <body>
-    <header>
-        <h1>Edit Claim</h1>
-        <nav>
-            <a href="{{ url_for('admin_claims') }}">Back to Claims List</a>
-        </nav>
-    </header>
-    <main>
-        <form action="{{ url_for('edit_claim', claim_id=claim.id) }}" method="post">
-            <label for="status">Status:</label>
-            <select id="status" name="status">
-                <option value="Pending" {% if claim.status == 'Pending' %}selected{% endif %}>Pending</option>
-                <option value="Approved" {% if claim.status == 'Approved' %}selected{% endif %}>Approved</option>
-                <option value="Denied" {% if claim.status == 'Denied' %}selected{% endif %}>Denied</option>
-            </select>
-            <br>
-            <input type="submit" value="Update Claim">
+    <div class="container mt-5">
+        <h2>Edit Claim</h2>
+        <form method="POST">
+            <div class="form-group">
+                <label for="status">Claim Status</label>
+                <select class="form-control" id="status" name="status">
+                    <option value="waiting_approval" {% if claim.status == 'waiting_approval' %}selected{% endif %}>Waiting Approval</option>
+                    <option value="approved" {% if claim.status == 'approved' %}selected{% endif %}>Approved</option>
+                    <option value="rejected" {% if claim.status == 'rejected' %}selected{% endif %}>Rejected</option>
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="admin_response">Admin Response</label>
+                <textarea class="form-control" id="admin_response" name="admin_response" rows="4">{{ claim.admin_response }}</textarea>
+            </div>
+            <button type="submit" class="btn btn-primary">Update Claim</button>
         </form>
-    </main>
+    </div>
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.5.4/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
 </body>
 </html>

--- a/agileapp/app/templates/view-claims.html
+++ b/agileapp/app/templates/view-claims.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>My Claims</title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+</head>
+<body>
+    <div class="container mt-5">
+        <h2>My Claims</h2>
+        <table class="table table-bordered">
+            <thead class="thead-dark">
+                <tr>
+                    <th>Item Name</th>
+                    <th>Claim Status</th>
+                    <th>Admin Response</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for claim, lost_item in claims %}
+                    <tr>
+                        <td>{{ lost_item.name }}</td>
+                        <td>{{ claim.status }}</td>
+                        <td>{{ claim.admin_response }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.5.4/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Admins are able to edit the admin_response field to respond to claims in the edit-claim page. (Update functionality)

Users now also have a view-claims page to view information about their claims (item, claim status as well as the admin's response to the claim).